### PR TITLE
Add mysql-client to tgf full docker image

### DIFF
--- a/Dockerfile.2.Full
+++ b/Dockerfile.2.Full
@@ -15,7 +15,7 @@ RUN apt-get update && \
     apt-get -y install python-software-properties
 
 # Install the basic command
-RUN apt-get -y install curl wget ksh zsh fish git unzip
+RUN apt-get -y install curl wget ksh zsh fish git unzip mysql-client
 
 # Install os-my-zsh
 RUN sh -c "$(curl -fsSL https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" || echo


### PR DESCRIPTION
Adding mysql-client to the full TGF docker image. Adding mysql-client would be useful to set up the databases we have created while running TGF.