### PR TITLE
Corrects the docker entrypoint flag to capital -E

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Returns the version of the default entry point (i.e. `Terragrunt`), the --versio
 to the desired entry point
 
 ```bash
-> tgf -e terraform -- --version
+> tgf -E terraform -- --version
 Terraform v0.9.11
 ```
 


### PR DESCRIPTION
This PR corrects the README to reflect the proper parameter name for specifying the container's entrypoint. With the existing README, the suggested terraform command fails:

```bash
$ tgf -e terraform -- --version
Incorrect Usage. flag provided but not defined: -e
```
After the correction:

```bash
$ tgf -E terraform -- --version
Terraform v0.11.5
```