### PR TITLE
Restore the custom naming based on config location

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,7 +4,6 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/go-getter"
 	"io"
 	"io/ioutil"
 	"os"
@@ -21,6 +20,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/coveo/gotemplate/collections"
 	"github.com/gruntwork-io/terragrunt/aws_helper"
+	"github.com/hashicorp/go-getter"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -107,7 +107,7 @@ func (cb TGFConfigBuild) GetTag() string {
 	if cb.Tag != "" {
 		return cb.Tag
 	}
-	return cb.hash()
+	return filepath.Base(filepath.Dir(cb.source))
 }
 
 // InitConfig returns a properly initialized TGF configuration struct

--- a/config_test.go
+++ b/config_test.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"crypto/md5"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -110,7 +108,7 @@ func TestSetConfigDefaultValues(t *testing.T) {
 	assert.Equal(t, "RUN ls test", config.imageBuildConfigs[1].Instructions)
 	assert.Equal(t, "/abspath/my-folder", config.imageBuildConfigs[1].Folder)
 	assert.Equal(t, "/abspath/my-folder", config.imageBuildConfigs[1].Dir())
-	assert.Equal(t, getHash([]string{"AWS", config.imageBuildConfigs[1].Instructions}), config.imageBuildConfigs[1].GetTag())
+	assert.Equal(t, "AWS", config.imageBuildConfigs[1].GetTag())
 
 	assert.Equal(t, "coveo/stuff", config.Image)
 	assert.Equal(t, "test", *config.ImageTag)
@@ -192,12 +190,4 @@ func randInt() int {
 	source := rand.NewSource(time.Now().UnixNano())
 	random := rand.New(source)
 	return random.Int()
-}
-
-func getHash(values []string) string {
-	h := md5.New()
-	for _, value := range values {
-		io.WriteString(h, value)
-	}
-	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Version is initialized at build time through -ldflags "-X main.Version=<version number>"
-var version = "1.18.1"
+var version = "1.18.5"
 
 var description = `
 DESCRIPTION:
@@ -83,6 +83,7 @@ var (
 	ErrPrintf  = utils.ColorErrorPrintf
 	ErrPrintln = utils.ColorErrorPrintln
 	ErrPrint   = utils.ColorErrorPrint
+	Split2     = collections.Split2
 )
 
 // Environment variables


### PR DESCRIPTION
The initial goal was to easily identify custom images instead of just having an anonymous hash to identify them. We then added a hash to ensure that we rebuild the image if the custom DockerFile or the custom build folder content changed and finally, we removed the name, thus  loosing the identification of the custom image and returning to an anonymous image as we did originally.

It is still important to not rebuild the custom image if there is no change and rebuild it if there is a change. So, I simply added the hash into a label and instead putting the hash into the name, we simply check if the label has changed to determine if the image should be rebuilt.