### PR TITLE
Remove potentially bad characters from docker tags

### DIFF
--- a/config.go
+++ b/config.go
@@ -104,10 +104,12 @@ func (cb TGFConfigBuild) Dir() string {
 
 // GetTag returns the tag name that should be added to the image
 func (cb TGFConfigBuild) GetTag() string {
+	tag := filepath.Base(filepath.Dir(cb.source))
 	if cb.Tag != "" {
-		return cb.Tag
+		tag = cb.Tag
 	}
-	return filepath.Base(filepath.Dir(cb.source))
+	tagRegex := regexp.MustCompile(`[^a-zA-Z0-9\._-]`)
+	return tagRegex.ReplaceAllString(tag, "")
 }
 
 // InitConfig returns a properly initialized TGF configuration struct


### PR DESCRIPTION
When creating a custom docker image. TGF sets the image tag as the directory name. If the directory has special characters in its name, it crashes due to docker not accepting the tag