### PR TITLE
Add --non-interactive option to run Docker without "-it" flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,36 +128,29 @@ section | Description
 
 ```text
 > tgf -H
-usage: ./tgf [<flags>]
+usage: tgf [<flags>]
 
-DESCRIPTION: TGF (terragrunt frontend) is a Docker frontend for terragrunt/terraform. It automatically maps your current folder, your HOME
-folder, your TEMP folder as well of most environment variables to the docker process. You can add -D to your command to get the exact docker command that is generated.
+DESCRIPTION: TGF (terragrunt frontend) is a Docker frontend for terragrunt/terraform. It automatically maps your current folder, your HOME folder, your TEMP folder as well of most environment variables to the docker process. You can add -D to your command to get the exact docker command that is generated.
 
-It then looks in your current folder and all its parents to find a file named '.tgf.config' to retrieve the default configuration. If not all configurable values are
-satisfied and you have an AWS configuration, it will then try to retrieve the missing elements from the AWS Parameter Store under the key '/default/tgf'.
+It then looks in your current folder and all its parents to find a file named '.tgf.config' to retrieve the default configuration. If not all configurable values are satisfied and you have an AWS configuration, it will then try to retrieve the missing elements from the AWS Parameter Store under the key '/default/tgf'.
 
-Configurable values are: docker-image, docker-image-version, docker-image-tag, docker-image-build, docker-image-build-folder, docker-image-build-tag, logging-level,
-entry-point, docker-refresh, docker-options, recommended-image-version, required-image-version, tgf-recommended-version, environment, run-before, run-after, alias.
+Configurable values are: docker-image, docker-image-version, docker-image-tag, docker-image-build, docker-image-build-folder, docker-image-build-tag, logging-level, entry-point, docker-refresh, docker-options, recommended-image-version, required-image-version, tgf-recommended-version, environment, run-before, run-after, alias.
 
-You can get the full documentation at https://github.com/coveo/tgf/blob/master/README.md and check for new version at
-https://github.com/coveo/tgf/releases/latest.
+You can get the full documentation at https://github.com/coveo/tgf/blob/master/README.md and check for new version at https://github.com/coveo/tgf/releases/latest.
 
 Any docker image could be used, but TGF specialized images could be found at: https://hub.docker.com/r/coveo/tgf/tags.
 
-Terragrunt documentation could be found at https://github.com/coveo/terragrunt/blob/master/README.md (Coveo fork) or
-https://github.com/gruntwork-io/terragrunt/blob/master/README.md (Gruntwork.io original)
+Terragrunt documentation could be found at https://github.com/coveo/terragrunt/blob/master/README.md (Coveo fork) or https://github.com/gruntwork-io/terragrunt/blob/master/README.md (Gruntwork.io original)
 
 Terraform documentation could be found at https://www.terraform.io/docs/index.html.
 
-IMPORTANT: Most of the tgf command line arguments are in uppercase to avoid potential conflict with the underlying command. If any of the tgf arguments conflicts with an
-argument of the desired entry point, you must place that argument after -- to ensure that they are not interpreted by tgf and are passed to the entry point. Any non
-conflicting argument will be passed to the entry point wherever it is located on the invocation arguments.
+IMPORTANT: Most of the tgf command line arguments are in uppercase to avoid potential conflict with the underlying command. If any of the tgf arguments conflicts with an argument of the desired entry point, you must place that argument after -- to ensure that they are not interpreted by tgf and are passed to the entry point. Any non conflicting argument will be passed to the entry point wherever it is located on the invocation arguments.
 
   tgf ls -- -D   # Avoid -D to be interpreted by tgf as --debug-docker
 
 It is also possible to specify additional arguments through environment variable TGF_ARGS or enable debugging mode through TGF_DEBUG.
 
-VERSION: 1.18.1
+VERSION: 1.19.1
 
 AUTHOR: Coveo
 
@@ -165,10 +158,13 @@ Flags:
   -H, --tgf-help                 Show context-sensitive help (also try --help-man).
   -D, --debug-docker             Print the docker command issued
   -F, --flush-cache              Invoke terragrunt with --terragrunt-update-source to flush the cache
-      --refresh-image            Force a refresh of the docker image (alias --ri)
       --get-image-name           Just return the resulting image name (alias --gi)
       --no-home                  Disable the mapping of the home directory (alias --nh)
       --no-temp                  Disable the mapping of the temp directory (alias --nt)
+      --refresh-image            Force a refresh of the docker image (alias --ri)
+      --local-image              If set, TGF will not pull the image when refreshing (alias --li)
+      --interactive              If set, docker will be launched in interactive mode, i.e. the -it flag will be passed 
+                                 to the docker cli (alias --it) or set TGF_INTERACTIVE
       --mount-point=MOUNT-POINT  Specify a mount point for the current folder --mp)
       --docker-arg=<opt> ...     Supply extra argument to Docker (alias --da)
       --ignore-user-config       Ignore all tgf.user.config files (alias --iuc)
@@ -181,7 +177,10 @@ Flags:
       --image-version=version    Use a different version of docker image instead of the default one (alias --iv)
   -T, --tag=latest               Use a different tag of docker image instead of the default one
   -P, --profile=PROFILE          Set the AWS profile configuration to use
-  -L, --logging-level=<level>    Set the logging level (critical=0, error=1, warning=2, notice=3, info=4, debug=5, full=6)
+  -L, --logging-level=<level>    Set the logging level (critical=0, error=1, warning=2, notice=3, info=4, debug=5, full=6) or set TGF_LOGGING_LEVEL
+      --ps-path=<path>           Parameter Store path used to find AWS common configuration shared by a team or set TGF_SSM_PATH
+      --config-location=<path>   Set the configuration location or set TGF_CONFIG_LOCATION
+      --config-files=<files>     Set the files to look for (default: TGFConfig) or set TGF_CONFIG_FILES
   ```
 
 Example:

--- a/arguments.go
+++ b/arguments.go
@@ -9,8 +9,8 @@ import (
 // ApplicationArguments allows proper management between managed and non managed arguments provided to kingpin
 type ApplicationArguments struct {
 	*kingpin.Application
-	longs  map[string]bool
-	shorts map[rune]bool
+	longs  map[string]bool // true if it is a switch (bool), false otherwise
+	shorts map[rune]bool   // true if it is a switch (bool), false otherwise
 }
 
 func (app ApplicationArguments) add(name, description string, isSwitch bool, shorts ...rune) *kingpin.FlagClause {
@@ -52,7 +52,12 @@ Arg:
 		}
 		if strings.HasPrefix(arg, "--") {
 			argSplit := strings.Split(args[i][2:], "=")
-			if isSwitch, ok := app.longs[argSplit[0]]; ok {
+			argumentName := argSplit[0]
+			// Handle kingpin negative flags (e.g.: --no-interactive vs --interactive)
+			if strings.HasPrefix(argumentName, "no-") {
+				argumentName = argumentName[3:]
+			}
+			if isSwitch, ok := app.longs[argumentName]; ok {
 				managed = append(managed, arg)
 				if !isSwitch && len(argSplit) == 1 {
 					// This is not a switch (bool flag) and there is no argument with

--- a/docker.go
+++ b/docker.go
@@ -74,10 +74,12 @@ func callDocker(withDockerMount bool, args ...string) int {
 	rootFolder := strings.Split(strings.TrimPrefix(cwd, currentDrive), "/")[0]
 
 	dockerArgs := []string{
-		"run", "-it",
-		"-v", fmt.Sprintf("%s%s:%s", convertDrive(currentDrive), rootFolder, filepath.ToSlash(filepath.Join("/", mountPoint, rootFolder))),
-		"-w", sourceFolder,
+		"run",
 	}
+	if dockerInteractive {
+		dockerArgs = append(dockerArgs, "-it")
+	}
+	dockerArgs = append(dockerArgs,"-v", fmt.Sprintf("%s%s:%s", convertDrive(currentDrive), rootFolder, filepath.ToSlash(filepath.Join("/", mountPoint, rootFolder))), "-w", sourceFolder)
 
 	if withDockerMount {
 		withDockerMountArgs := []string{"-v", fmt.Sprintf(dockerSocketMountPattern, dockerSocketFile), "--group-add", getDockerGroup()}

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ var (
 	noTemp            bool
 	refresh           bool
 	useLocalImage     bool
+	dockerInteractive = true
 )
 
 var must = errors.Must
@@ -94,6 +95,7 @@ const (
 	envPSPath      = "TGF_SSM_PATH"
 	envLocation    = "TGF_CONFIG_LOCATION"
 	envConfigFiles = "TGF_CONFIG_FILES"
+	envInteractive = "TGF_INTERACTIVE"
 )
 
 func main() {
@@ -145,6 +147,7 @@ func main() {
 	app.Switch("no-temp", "Disable the mapping of the temp directory (alias --nt)").BoolVar(&noTemp)
 	app.Switch("refresh-image", "Force a refresh of the docker image (alias --ri)").BoolVar(&refresh)
 	app.Switch("local-image", "If set, TGF will not pull the image when refreshing (alias --li)").BoolVar(&useLocalImage)
+	app.Switch("interactive", "If set, docker will be launched in interactive mode, i.e. the -it flag will be passed to the docker cli (alias --it) or set "+envPSPath).Envar(envInteractive).BoolVar(&dockerInteractive)
 	app.Argument("mount-point", "Specify a mount point for the current folder --mp)").StringVar(&mountPoint)
 	app.Argument("docker-arg", "Supply extra argument to Docker (alias --da)").PlaceHolder("<opt>").StringsVar(&dockerOptions)
 	app.Argument("ignore-user-config", "Ignore all tgf.user.config files (alias --iuc)").BoolVar(&disableUserConfig)
@@ -173,6 +176,7 @@ func main() {
 	app.Switch("av", "alias for all-versions").Hidden().BoolVar(getAllVersions)
 	app.Switch("wd", "alias for with-docker").Hidden().BoolVar(withDockerMount)
 	app.Switch("li", "alias for local-image").Hidden().BoolVar(&useLocalImage)
+	app.Switch("it", "alias for interactive").Hidden().BoolVar(&dockerInteractive)
 	app.Argument("da", "alias for docker-arg").Hidden().StringsVar(&dockerOptions)
 	app.Argument("iv", "alias for image-version").Default("-").Hidden().StringVar(imageVersion)
 	app.Argument("mp", "alias for mount-point").Hidden().StringVar(&mountPoint)

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Version is initialized at build time through -ldflags "-X main.Version=<version number>"
-var version = "1.19.0"
+var version = "1.19.1"
 
 var description = `
 DESCRIPTION:
@@ -147,7 +147,7 @@ func main() {
 	app.Switch("no-temp", "Disable the mapping of the temp directory (alias --nt)").BoolVar(&noTemp)
 	app.Switch("refresh-image", "Force a refresh of the docker image (alias --ri)").BoolVar(&refresh)
 	app.Switch("local-image", "If set, TGF will not pull the image when refreshing (alias --li)").BoolVar(&useLocalImage)
-	app.Switch("interactive", "If set, docker will be launched in interactive mode, i.e. the -it flag will be passed to the docker cli (alias --it) or set "+envPSPath).Envar(envInteractive).BoolVar(&dockerInteractive)
+	app.Switch("interactive", "If set, docker will be launched in interactive mode, i.e. the -it flag will be passed to the docker cli (alias --it) or set "+envInteractive).Envar(envInteractive).BoolVar(&dockerInteractive)
 	app.Argument("mount-point", "Specify a mount point for the current folder --mp)").StringVar(&mountPoint)
 	app.Argument("docker-arg", "Supply extra argument to Docker (alias --da)").PlaceHolder("<opt>").StringsVar(&dockerOptions)
 	app.Argument("ignore-user-config", "Ignore all tgf.user.config files (alias --iuc)").BoolVar(&disableUserConfig)
@@ -183,7 +183,7 @@ func main() {
 	app.Argument("iu", "alias for ignore-user-config").Hidden().BoolVar(&disableUserConfig)
 	app.Argument("iuc", "alias for ignore-user-config").Hidden().BoolVar(&disableUserConfig)
 
-	// Split up the managed parameters from the unmanaged ones
+	// Split up the managed parameters from the unmanaged onese
 	if extraArgs, ok := os.LookupEnv(envArgs); ok {
 		os.Args = append(os.Args, strings.Split(extraArgs, " ")...)
 	}


### PR DESCRIPTION
Needed to run tgf as part of unit tests (with pytest for example)