### PR TITLE
Recursive alias parsing

### DIFF
--- a/config.go
+++ b/config.go
@@ -328,10 +328,10 @@ func (config *TGFConfig) ParseAliases(args []string) []string {
 					result[i] = result[i].RestoreProtected(quoted).Trim(`"`)
 				}
 			}
-			return append(result.Strings(), args[1:]...)
+			return append(config.ParseAliases(result.Strings()), args[1:]...)
 		}
 	}
-	return nil
+	return args
 }
 
 func readSSMParameterStore(ssmParameterFolder string) map[string]string {

--- a/config_test.go
+++ b/config_test.go
@@ -181,6 +181,7 @@ func TestParseAliases(t *testing.T) {
 			"to_replace": "one two three,four",
 			"other_arg1": "will not be replaced",
 			"with_quote": `quoted arg1 "arg 2" -D -it --rm`,
+			"recursive":  "to_replace five",
 		},
 	}
 
@@ -191,11 +192,12 @@ func TestParseAliases(t *testing.T) {
 		want   []string
 	}{
 		{"Nil", config, nil, nil},
-		{"Empty", config, []string{}, nil},
-		{"Unchanged", config, strings.Split("whatever the args are", " "), nil},
+		{"Empty", config, []string{}, []string{}},
+		{"Unchanged", config, strings.Split("whatever the args are", " "), []string{"whatever", "the", "args", "are"}},
 		{"Replaced", config, strings.Split("to_replace with some args", " "), []string{"one", "two", "three,four", "with", "some", "args"}},
 		{"Replaced 2", config, strings.Split("to_replace other_arg1", " "), []string{"one", "two", "three,four", "other_arg1"}},
 		{"Replaced with quote", config, strings.Split("with_quote 1 2 3", " "), []string{"quoted", "arg1", "arg 2", "-D", "-it", "--rm", "1", "2", "3"}},
+		{"Recursive", config, strings.Split("recursive", " "), []string{"one", "two", "three,four", "five"}},
 	}
 
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -197,7 +197,7 @@ func main() {
 	must(app.Parse(managed))
 	config.SetDefaultValues(*psPath, *configLocation, *configFiles)
 
-	if alias := config.ParseAliases(unmanaged); alias != nil {
+	if alias := config.ParseAliases(unmanaged); alias[0] != unmanaged[0] {
 		if managed, unmanaged = app.SplitManaged(append(os.Args[:1], alias...)); len(managed) != 0 {
 			must(app.Parse(managed))
 		}


### PR DESCRIPTION
For example we could define the following:
"_my_image": " --image-version ver --image=image/image",
"mycommand": "_my_image -E cmd",
 "mycommand2": "_my_image -E cmd2",