### PR TITLE
Allow the arg="value" format in alias definitions

### DIFF
--- a/config.go
+++ b/config.go
@@ -325,7 +325,7 @@ func (config *TGFConfig) ParseAliases(args []string) []string {
 			result = replace.Fields()
 			if len(quoted) > 0 {
 				for i := range result {
-					result[i] = result[i].RestoreProtected(quoted).Trim(`"`)
+					result[i] = result[i].RestoreProtected(quoted).ReplaceN(`="`, "=", 1).Trim(`"`)
 				}
 			}
 			return append(config.ParseAliases(result.Strings()), args[1:]...)

--- a/config_test.go
+++ b/config_test.go
@@ -180,7 +180,7 @@ func TestParseAliases(t *testing.T) {
 		Aliases: map[string]string{
 			"to_replace": "one two three,four",
 			"other_arg1": "will not be replaced",
-			"with_quote": `quoted arg1 "arg 2" -D -it --rm`,
+			"with_quote": `quoted arg1 "arg 2" arg3="arg4 arg5" -D -it --rm`,
 			"recursive":  "to_replace five",
 		},
 	}
@@ -196,7 +196,7 @@ func TestParseAliases(t *testing.T) {
 		{"Unchanged", config, strings.Split("whatever the args are", " "), []string{"whatever", "the", "args", "are"}},
 		{"Replaced", config, strings.Split("to_replace with some args", " "), []string{"one", "two", "three,four", "with", "some", "args"}},
 		{"Replaced 2", config, strings.Split("to_replace other_arg1", " "), []string{"one", "two", "three,four", "other_arg1"}},
-		{"Replaced with quote", config, strings.Split("with_quote 1 2 3", " "), []string{"quoted", "arg1", "arg 2", "-D", "-it", "--rm", "1", "2", "3"}},
+		{"Replaced with quote", config, strings.Split("with_quote 1 2 3", " "), []string{"quoted", "arg1", "arg 2", "arg3=arg4 arg5", "-D", "-it", "--rm", "1", "2", "3"}},
 		{"Recursive", config, strings.Split("recursive", " "), []string{"one", "two", "three,four", "five"}},
 	}
 


### PR DESCRIPTION
Putting `--da="-e NODE_PATH=/generator-tgf/node_modules"` in an alias configuration would parse to `"-e NODE_PATH=/generator-tgf/node_modules` (bad quote at the beginning)