### PR TITLE
 Fix broken disable flags (since 1.19.1)

### DIFF
--- a/application.go
+++ b/application.go
@@ -58,9 +58,13 @@ Arg:
 		if strings.HasPrefix(arg, "--") {
 			argSplit := strings.Split(args[i][2:], "=")
 			argumentName := argSplit[0]
-			// Handle kingpin negative flags (e.g.: --no-interactive vs --interactive)
-			if strings.HasPrefix(argumentName, "no-") {
-				argumentName = argumentName[3:]
+			// Handle kingpin negative flags (e.g.: --no-interactive vs --interactive) but only if they exist
+			isNegative := strings.HasPrefix(argumentName, "no-")
+			if isNegative {
+				nonNegativeName := argumentName[3:]
+				if _, ok := app.longs[nonNegativeName]; ok {
+					argumentName = nonNegativeName
+				}
 			}
 			if isSwitch, ok := app.longs[argumentName]; ok {
 				managed = append(managed, arg)

--- a/cli_test.go
+++ b/cli_test.go
@@ -65,7 +65,7 @@ func TestNewApplicationWithOptionsAndAliases(t *testing.T) {
 
 			app := NewTGFApplication()
 			app.ParseAliases(config)
-			assert.Equal(t, tt.wantUnmanaged, app.UnmanagedArgs)
+			assert.Equal(t, tt.wantUnmanaged, app.UnmanagedArgs, "Unmanaged args are not equal")
 
 			for wantField, wantValueInt := range tt.wantOptions {
 				if wantValue, ok := wantValueInt.(bool); ok {

--- a/cli_test.go
+++ b/cli_test.go
@@ -32,28 +32,34 @@ func TestNewApplicationWithOptionsAndAliases(t *testing.T) {
 			nil,
 		},
 		{
-			"Managed Arg",
+			"Managed arg",
 			config, []string{"--ri"},
 			map[string]interface{}{"Refresh": true},
 			nil,
 		},
 		{
-			"Managed and unmanaged Args",
+			"Managed and unmanaged arg",
 			config, []string{"--li", "--stuff"},
 			map[string]interface{}{"UseLocalImage": true},
 			[]string{"--stuff"},
 		},
 		{
-			"WithAliases",
+			"Alias with an unmanaged arg",
 			config, []string{"my_recursive_alias", "--stuff4"},
 			map[string]interface{}{"Refresh": true, "UseLocalImage": true, "WithDockerMount": true},
 			[]string{"--stuff3", "--stuff4"},
 		},
 		{
-			"WithAliasesAndArgs",
+			"Alias with an argument",
 			config, []string{"my_recursive_alias", "--no-interactive"},
 			map[string]interface{}{"DockerInteractive": false},
 			[]string{"--stuff3"},
+		},
+		{
+			"Disable flag (shown as `no` in the help)",
+			config, []string{"--no-aws"},
+			map[string]interface{}{"NoAWS": true},
+			nil,
 		},
 	}
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -61,6 +61,12 @@ func TestNewApplicationWithOptionsAndAliases(t *testing.T) {
 			map[string]interface{}{"NoAWS": true},
 			nil,
 		},
+		{
+			"Disable short flag (shown as `no` in the help)",
+			config, []string{"--na"},
+			map[string]interface{}{"NoAWS": true},
+			nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ type (
 	String = collections.String
 )
 
-var config = InitConfig()
 var app *TGFApplication
 
 // Function Aliases
@@ -49,6 +48,7 @@ func main() {
 	}()
 
 	app = NewTGFApplication()
+	config := InitConfig()
 	config.SetDefaultValues(app.PsPath, app.ConfigLocation, app.ConfigFiles)
 	app.ParseAliases(config)
 
@@ -74,7 +74,7 @@ func main() {
 		config.EntryPoint = app.Entrypoint
 	}
 
-	if !validateVersion(app.ImageVersion) {
+	if !validateVersion(config, app.ImageVersion) {
 		os.Exit(1)
 	}
 
@@ -102,7 +102,7 @@ func main() {
 	}
 
 	if app.PruneImages {
-		prune(config.Image)
+		prune(config, config.Image)
 		os.Exit(0)
 	}
 
@@ -113,17 +113,17 @@ func main() {
 	}
 
 	if config.ImageVersion == nil {
-		actualVersion := GetActualImageVersion()
+		actualVersion := GetActualImageVersion(config)
 		config.ImageVersion = &actualVersion
-		if !validateVersion(app.ImageVersion) {
+		if !validateVersion(config, app.ImageVersion) {
 			os.Exit(2)
 		}
 	}
 
-	os.Exit(callDocker(app.UnmanagedArgs...))
+	os.Exit(callDocker(config, app.UnmanagedArgs...))
 }
 
-func validateVersion(version string) bool {
+func validateVersion(config *TGFConfig, version string) bool {
 	for _, err := range config.Validate() {
 		switch err := err.(type) {
 		case ConfigWarning:


### PR DESCRIPTION
Since the support for `no-` was added, switches with no by default were broken

Also remove global `config`