### PR TITLE
Prune dangling images and containers on a best-effort basis

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -290,12 +290,16 @@ func getImage(config *TGFConfig, noDockerBuild bool, refresh bool, useLocalImage
 	return
 }
 
-var pruneDangling = func(config *TGFConfig) {
+func pruneDangling(config *TGFConfig) {
 	cli, ctx := getDockerClient()
 	danglingFilters := filters.NewArgs()
 	danglingFilters.Add("dangling", "true")
-	must(cli.ImagesPrune(ctx, danglingFilters))
-	must(cli.ContainersPrune(ctx, filters.Args{}))
+	if _, err := cli.ImagesPrune(ctx, danglingFilters); err != nil {
+		printError("Error pruning dangling images (Untagged): %v", err.Error())
+	}
+	if _, err := cli.ContainersPrune(ctx, filters.Args{}); err != nil {
+		printError("Error pruning unused containers: %v", err.Error())
+	}
 }
 
 func prune(config *TGFConfig, images ...string) {

--- a/docker_test.go
+++ b/docker_test.go
@@ -11,8 +11,6 @@ import (
 func TestGetImage(t *testing.T) {
 	t.Parallel()
 
-	pruneDangling = func(*TGFConfig) {}
-
 	testImageName := "test-image" + strconv.Itoa(randInt())
 	testTag := "test" + strconv.Itoa(randInt())
 


### PR DESCRIPTION
This shouldn't be a necessary step to running TGF