### PR TITLE
Removed the current user argument on windows

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -86,7 +86,8 @@ func callDocker(config *TGFConfig, args ...string) int {
 		dockerArgs = append(dockerArgs, withDockerMountArgs...)
 	}
 
-	if app.WithCurrentUser {
+	// No need to map to current user on windows. Files written by docker containers in windows seem to be accessible by the user calling docker
+	if app.WithCurrentUser && runtime.GOOS != "windows" {
 		currentUser := must(user.Current()).(*user.User)
 		dockerArgs = append(dockerArgs, fmt.Sprintf("--user=%s:%s", currentUser.Uid, currentUser.Gid))
 	}


### PR DESCRIPTION
Following tests by @dblanchette, we have noticed that It doesn't work and it is not needed