### PR TITLE
Fix the help flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is initialized at build time through -ldflags "-X main.Version=<version number>"
-var version = "1.20.2"
+var version = "1.21.0-beta2"
 
 func main() {
 	// Handle eventual panic message


### PR DESCRIPTION
With the forked version of kingpin, there was a side effect with the --help flag. Previously, the help flag was not considered as managed and it was not handled by kingpin. This was the desired behavior since we do not want to interfere with the sub command executed by terraform which most likely will have a --help.