### PR TITLE
[DT-1631] - get latest tgf script to use s3 file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ You can run the `get-latest-tgf.sh` script to check if you have the latest versi
 curl https://raw.githubusercontent.com/coveo/tgf/master/get-latest-tgf.sh | bash
 ```
 
-> PS: The **GITHUB_TOKEN** environement variable can be set to make authenticated requests to github; as well as the **TGF_PATH** variable to set the directory of installation. By default, TGF_PATH is `/usr/local/bin`.
-
 On `Windows` with Powershell:
 
 ```powershell

--- a/get-latest-tgf.sh
+++ b/get-latest-tgf.sh
@@ -12,17 +12,14 @@ get_local_tgf_version () {
 }
 
 get_latest_tgf_version () {
-    if [ -z "$GITHUB_TOKEN" ]
-    then
-        echo 'GITHUB_TOKEN is not set.'
-    fi    
-    
-    TGF_LATEST_VERSION=$(curl --silent https://api.github.com/repos/coveo/tgf/releases/latest?access_token=${GITHUB_TOKEN} | grep tag_name | awk -F\" '{print $4}')
+    TGF_LATEST_VERSION=$(curl --silent https://coveo-bootstrap-us-east-1.s3.amazonaws.com/tgf_version.txt)
     
     if [ -z "$TGF_LATEST_VERSION" ]
     then 
-        echo "Could not obtain tgf latest version. (check your GITHUB_TOKEN)"
+        echo "Could not obtain tgf latest version."
         exit 1
+    else 
+        TGF_LATEST_VERSION=v$TGF_LATEST_VERSION # Appending a v in front of the version number for consistency
     fi
 }
 

--- a/get-latest-tgf.sh
+++ b/get-latest-tgf.sh
@@ -8,7 +8,7 @@ if [ ! -d "$TGF_PATH" ]; then
 fi
 
 get_local_tgf_version () {
-    TGF_LOCAL_VERSION=$($TGF --current-version | awk -F\  '{print $2}')
+    TGF_LOCAL_VERSION=$($TGF --current-version | awk -F\  '{print $2}' | cut -d'v' -f 2)
 }
 
 get_latest_tgf_version () {
@@ -18,8 +18,6 @@ get_latest_tgf_version () {
     then 
         echo "Could not obtain tgf latest version."
         exit 1
-    else 
-        TGF_LATEST_VERSION=v$TGF_LATEST_VERSION # Appending a v in front of the version number for consistency
     fi
 }
 
@@ -30,16 +28,14 @@ script_end () {
 }
 
 install_latest_tgf () {
-    VERSION=$(echo $TGF_LATEST_VERSION | cut -d'v' -f 2)
-
     if [[ $(uname -s) == Linux ]]
     then
         echo 'Installing latest tgf version for Linux in' $TGF_PATH '...'
-        curl -sL "https://github.com/coveo/tgf/releases/download/v"$VERSION"/tgf_"$VERSION"_linux_64-bits.zip" | gzip -d > $TGF && chmod +x $TGF && script_end
+        curl -sL "https://github.com/coveo/tgf/releases/download/v"$TGF_LATEST_VERSION"/tgf_"$TGF_LATEST_VERSION"_linux_64-bits.zip" | gzip -d > $TGF && chmod +x $TGF && script_end
     elif [[ $(uname -s) == Darwin ]]
     then
         echo 'Installing latest tgf for OSX in' $TGF_PATH '...'
-        curl -sL "https://github.com/coveo/tgf/releases/download/v"$VERSION"/tgf_"$VERSION"_macOS_64-bits.zip" | bsdtar -xf- -C $TGF_PATH && script_end
+        curl -sL "https://github.com/coveo/tgf/releases/download/v"$TGF_LATEST_VERSION"/tgf_"$TGF_LATEST_VERSION"_macOS_64-bits.zip" | bsdtar -xf- -C $TGF_PATH && script_end
     else 
         echo 'OS not supported.'
         exit 1


### PR DESCRIPTION
Changed `get-latest-tgf` script to now use the file stored on `s3` instead of directly querying the Github api in order to avoid throttling.